### PR TITLE
Fixed shield tags, preventing selecting shields for various systems.

### DIFF
--- a/assets/units/size_l/ship_dga_l_megathron.xml
+++ b/assets/units/size_l/ship_dga_l_megathron.xml
@@ -388,7 +388,7 @@
 			<connection name="con_shieldgen_l_2" tags="large shield hittable standard">
 				<offset>
 					<position x="54.859700000000004" y="-53.2854" z="-44.522"/>
-					<quaternion qw="-0.001699825976313766" qx="0.0001609997637102523" qy="-0.999986532379427" qz="-0.0049009928071052575"/>
+					<quaternion qw="-0.0001608267942032416" qx="-0.0016999992045405687" qy="0.004900997706737251" qz="-0.9999865320887703"/>
 				</offset>
 			</connection>
 		</connections>

--- a/assets/units/size_l/ship_dga_l_megathron.xml
+++ b/assets/units/size_l/ship_dga_l_megathron.xml
@@ -379,13 +379,13 @@
 					<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_1" tags="large shield hittable">
+			<connection name="con_shieldgen_l_1" tags="large shield hittable standard">
 				<offset>
 					<position x="-54.859700000000004" y="-53.2854" z="-44.522"/>
 					<quaternion qw="-0.0001608267942032416" qx="-0.0016999992045405687" qy="0.004900997706737251" qz="-0.9999865320887703"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_2" tags="large shield hittable">
+			<connection name="con_shieldgen_l_2" tags="large shield hittable standard">
 				<offset>
 					<position x="54.859700000000004" y="-53.2854" z="-44.522"/>
 					<quaternion qw="-0.001699825976313766" qx="0.0001609997637102523" qy="-0.999986532379427" qz="-0.0049009928071052575"/>

--- a/assets/units/size_l/ship_dga_l_obelisk.xml
+++ b/assets/units/size_l/ship_dga_l_obelisk.xml
@@ -184,7 +184,7 @@
 					<quaternion qw="-0.09512876169048609" qx="-0.0" qy="0.0" qz="-0.9954649761288614"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_2" tags="large shield hittable">
+			<connection name="con_shieldgen_l_2" tags="large shield hittable standard">
 				<offset>
 					<position x="99.7577" y="-391.0023" z="133.9799"/>
 					<quaternion qw="-0.09512477982982044" qx="0.0" qy="-0.0" qz="0.9954653566359445"/>


### PR DESCRIPTION
List of fixed ships:
Megathron: Main shields, rotation for shield 2.
Obelisk: Main shield 2.